### PR TITLE
fix: use output parameters to generate the testcase and datasource prefix dynamically

### DIFF
--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -3,7 +3,8 @@ name: Scheduled Loadtest
 on:
   schedule:
     # Do a run every sunday night
-    - cron: 12 5 * * 0
+    # - cron: 12 5 * * 0
+    - cron: "*/5 * * * *"
 
 env:
   CLI: "v0.38.0"
@@ -25,8 +26,8 @@ jobs:
       id: repository
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-        echo "::set-output name=datasource-prefix::${repo}"
-        echo "::set-output name=testcase::demo/${repo}-${TARGET_ENV}"
+        echo "::set-env name=DATASOURCE_PREFIX::${repo}"
+        echo "::set-env name=TESTCASE::demo/${repo}-${TARGET_ENV}"
 
     - name: StormForger | Install forge CLI
       run: |
@@ -37,12 +38,12 @@ jobs:
     - name: StormForger | Upload data-sources
       run: |
         ./scripts/data-source.sh "${TARGET_ENV}" # export test-data
-        ./forge datasource push demo *.csv --name-prefix-path="${{ steps.repository.outputs.datasource-prefix }}" --auto-field-names
+        ./forge datasource push demo *.csv --name-prefix-path="${DATASOURCE_PREFIX}" --auto-field-names
 
     - name: StormForger | Launch test-run
       run: |
         ./scripts/compile-loadtest.sh "${TARGET_ENV}" "/tmp/testcase.js"
-        ./forge test-case launch "${{ steps.repository.outputs.testcase }}" --test-case-file="/tmp/testcase.js" \
+        ./forge test-case launch "${TESTCASE}" --test-case-file="/tmp/testcase.js" \
           --title="${TITLE}" --notes="${NOTES}" ${LAUNCH_ARGS}
       env:
         LAUNCH_ARGS: "--nfr-check-file=./loadtest/loadtest.nfr.yaml"

--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -14,11 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TARGET_ENV: "production"
-      TESTCASE: "demo/${{ github.event.repository.name }}-production"
       STORMFORGER_JWT: ${{ secrets.STORMFORGER_JWT }}
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+
+    # Note: we need to manually extract the repository name (w/o the orga),
+    # since the github scheduled event does not bring the repository subobject.
+    - name: StormForger | Extract repository name
+      id: repository
+      run: |
+        repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+        echo "::set-output name=datasource-prefix::${repo}"
+        echo "::set-output name=testcase::demo/${repo}-${TARGET_ENV}"
 
     - name: StormForger | Install forge CLI
       run: |
@@ -29,12 +37,12 @@ jobs:
     - name: StormForger | Upload data-sources
       run: |
         ./scripts/data-source.sh "${TARGET_ENV}" # export test-data
-        ./forge datasource push demo *.csv --name-prefix-path="${{ github.event.repository.name }}/${TARGET_ENV}/" --auto-field-names
+        ./forge datasource push demo *.csv --name-prefix-path="${{ steps.repository.outputs.datasource-prefix }}" --auto-field-names
 
     - name: StormForger | Launch test-run
       run: |
         ./scripts/compile-loadtest.sh "${TARGET_ENV}" "/tmp/testcase.js"
-        ./forge test-case launch "${TESTCASE}" --test-case-file="/tmp/testcase.js" \
+        ./forge test-case launch "${{ steps.repository.outputs.testcase }}" --test-case-file="/tmp/testcase.js" \
           --title="${TITLE}" --notes="${NOTES}" ${LAUNCH_ARGS}
       env:
         LAUNCH_ARGS: "--nfr-check-file=./loadtest/loadtest.nfr.yaml"


### PR DESCRIPTION
### Why?

The github workflow does not have a `github.event.repository` object when run via a scheduled event. Thus we need to extract the repository name (without the orga) manually from the available metadata.

### What?

Extract the name via echo + cut and make it available as two github env variables: once for the test case name and once for the datasource prefix.