### PR TITLE
Fix env variables

### DIFF
--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -22,8 +22,7 @@ jobs:
       id: repository
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-        echo "::set-env name=DATASOURCE_PREFIX::${repo}"
-        echo "::set-env name=TESTCASE::demo/${repo}-${TARGET_ENV}"
+        echo "::set-output name=name::${repo}"
 
     - name: StormForger | Install forge CLI
       run: |
@@ -35,6 +34,8 @@ jobs:
       run: |
         ./scripts/data-source.sh "${TARGET_ENV}" # export test-data
         ./forge datasource push demo *.csv --name-prefix-path="${DATASOURCE_PREFIX}" --auto-field-names
+      env:
+        DATASOURCE_PREFIX: "${{steps.repository.outputs.name}}"
 
     - name: StormForger | Launch test-run
       run: |
@@ -42,6 +43,7 @@ jobs:
         ./forge test-case launch "${TESTCASE}" --test-case-file="/tmp/testcase.js" \
           --title="${TITLE}" --notes="${NOTES}" ${LAUNCH_ARGS}
       env:
+        TESTCASE: "demo/${{steps.repository.outputs.name}}-${TARGET_ENV}"
         LAUNCH_ARGS: "--nfr-check-file=./loadtest/loadtest.nfr.yaml"
         NOTES: |
           Name | Value

--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -10,7 +10,6 @@ jobs:
     name: "Load-Test (Production)"
     runs-on: ubuntu-latest
     env:
-      TARGET_ENV: "production"
       STORMFORGER_JWT: ${{ secrets.STORMFORGER_JWT }}
     steps:
     - name: Check out code into the Go module directory
@@ -18,11 +17,12 @@ jobs:
 
     # Note: we need to manually extract the repository name (w/o the orga),
     # since the github scheduled event does not bring the repository subobject.
-    - name: StormForger | Extract repository name
-      id: repository
+    - name: StormForger | Setup variables
+      id: config
       run: |
         repo=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-        echo "::set-output name=name::${repo}"
+        echo "::set-output name=repository::${repo}"
+        echo "::set-output name=target_env::production"
 
     - name: StormForger | Install forge CLI
       run: |
@@ -35,7 +35,8 @@ jobs:
         ./scripts/data-source.sh "${TARGET_ENV}" # export test-data
         ./forge datasource push demo *.csv --name-prefix-path="${DATASOURCE_PREFIX}" --auto-field-names
       env:
-        DATASOURCE_PREFIX: "${{steps.repository.outputs.name}}"
+        DATASOURCE_PREFIX: "${{steps.config.outputs.repository}}"
+        TARGET_ENV: "${{steps.config.outputs.target_env}}"
 
     - name: StormForger | Launch test-run
       run: |
@@ -43,7 +44,8 @@ jobs:
         ./forge test-case launch "${TESTCASE}" --test-case-file="/tmp/testcase.js" \
           --title="${TITLE}" --notes="${NOTES}" ${LAUNCH_ARGS}
       env:
-        TESTCASE: "demo/${{steps.repository.outputs.name}}-${TARGET_ENV}"
+        TARGET_ENV: "${{steps.config.outputs.target_env}}"
+        TESTCASE: "demo/${{steps.config.outputs.repository}}-${{steps.config.outputs.target_env}}"
         LAUNCH_ARGS: "--nfr-check-file=./loadtest/loadtest.nfr.yaml"
         NOTES: |
           Name | Value


### PR DESCRIPTION
Followup to #11  which still failed: https://github.com/stormforger/example-github-actions/actions/runs/403530996

We cannot use ENV variables inside a definition of another ENV variable. This PR moves the `TARGET_ENV` to the action variables instead.