### PR TITLE
Adds proper quotations for label params

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,11 +63,11 @@ jobs:
         ./forge test-case launch "${TESTCASE}" --test-case-file="./loadtest/loadtest.mjs" \
           --define ENV=\"${TARGET_ENV}\" \
           --title="${TITLE}" --notes="${NOTES}" \
-          --label=git-ref=${{github.ref}} \
-          --label=gh-commit=${{github.event.head_commit.url}} \
-          --label=gh-workflow=${{github.workflow}} \
-          --label=gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} \
-          --label=gh-actor=${{github.actor}} \
+          --label="git-ref=${{github.ref}}" \
+          --label="gh-commit=${{github.event.head_commit.url}}" \
+          --label="gh-workflow=${{github.workflow}}" \
+          --label="gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" \
+          --label="gh-actor=${{github.actor}}" \
             ${LAUNCH_ARGS}
       env:
         LAUNCH_ARGS: "--validate"
@@ -105,11 +105,11 @@ jobs:
         ./forge test-case launch "${TESTCASE}" --test-case-file="./loadtest/loadtest.mjs" \
           --define ENV=\"${TARGET_ENV}\" \
           --title="${TITLE}" --notes="${NOTES}" \
-          --label=git-ref=${{github.ref}} \
-          --label=gh-commit=${{github.event.head_commit.url}} \
-          --label=gh-workflow=${{github.workflow}} \
-          --label=gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} \
-          --label=gh-actor=${{github.actor}} \
+          --label="git-ref=${{github.ref}}" \
+          --label="gh-commit=${{github.event.head_commit.url}}" \
+          --label="gh-workflow=${{github.workflow}}" \
+          --label="gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" \
+          --label="gh-actor=${{github.actor}}" \
             ${LAUNCH_ARGS}
       env:
         LAUNCH_ARGS: "--nfr-check-file=./loadtest/loadtest.nfr.yaml"

--- a/.github/workflows/scheduled-loadtest.yml
+++ b/.github/workflows/scheduled-loadtest.yml
@@ -44,11 +44,11 @@ jobs:
         ./forge test-case launch "${TESTCASE}" --test-case-file="loadtest/loadtest.mjs" \
           --define ENV=\"${TARGET_ENV}\" \
           --title="${TITLE}" --notes="${NOTES}" \
-          --label=git-ref=${{github.ref}} \
-          --label=gh-commit=${{github.event.head_commit.url}} \
-          --label=gh-workflow=${{github.workflow}} \
-          --label=gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} \
-          --label=gh-actor=${{github.actor}} \
+          --label="git-ref=${{github.ref}}" \
+          --label="gh-commit=${{github.event.head_commit.url}}" \
+          --label="gh-workflow=${{github.workflow}}" \
+          --label="gh-run-url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" \
+          --label="gh-actor=${{github.actor}}" \
             ${LAUNCH_ARGS}
       env:
         TARGET_ENV: "${{steps.config.outputs.target_env}}"


### PR DESCRIPTION
See: #14, #15

The build failed because of missing quotes: https://github.com/stormforger/example-github-actions/runs/2912291941?check_suite_focus=true

Let's add some quotes…

We also made some changes to the API to allow for empty label values.

Test: https://github.com/stormforger/example-github-actions/runs/2913103481?check_suite_focus=true